### PR TITLE
Point to actual release of sbt-paradox-project-info

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ name             := "sbt-paradox-lightbend-project-info"
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "2.0.0")
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
-homepage := Some(url("https://github.com/lightbend/sbt-paradox-project-info"))
+homepage := Some(url("https://github.com/lightbend/sbt-paradox-lightbend-project-info"))
 scmInfo := Some(
   ScmInfo(
     url("https://github.com/lightbend/sbt-paradox-lightbend-project-info"),
@@ -27,7 +27,7 @@ developers += Developer(
   "contributors",
   "Contributors",
   "https://gitter.im/lightbend/paradox",
-  url("https://github.com/lightbend/sbt-paradox-project-info/graphs/contributors")
+  url("https://github.com/lightbend/sbt-paradox-lightbend-project-info/graphs/contributors")
 )
 organizationName := "Lightbend Inc."
 startYear        := Some(2018)

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ crossSbtVersions := List("1.1.0")
 organization     := "com.lightbend.paradox"
 name             := "sbt-paradox-lightbend-project-info"
 
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "1.1.11-SNAPSHOT")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "2.0.0")
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 homepage := Some(url("https://github.com/lightbend/sbt-paradox-project-info"))


### PR DESCRIPTION
Points to the new release of sbt-paradox-project-info. Also since this PR triggers github actions you can add the status checks to the `main` branch.

Let me know when a release is made at which point I will make a PR at https://github.com/akka/akka-paradox with the new release.