### PR TITLE
Upgrade sbt-paradox-project-info to move away from repo.scala-sbt.org

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ crossSbtVersions := List("1.4.9")
 organization     := "com.lightbend.paradox"
 name             := "sbt-paradox-lightbend-project-info"
 
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "3.0.0")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "3.0.1")
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 homepage := Some(url("https://github.com/lightbend/sbt-paradox-lightbend-project-info"))


### PR DESCRIPTION
I started to block [repo.scala-sbt.org](http://repo.scala-sbt.org/) and [repo.typesafe.com](http://repo.typesafe.com/) in my `/etc/hosts`.

sbt-paradox-project-info pulls in some dependencies that are still hosted on deprecated repo.scala-sbt.org.

- See https://github.com/lightbend/sbt-paradox-project-info/pull/40 which this pull request depends on.